### PR TITLE
Update component versions in download.properties

### DIFF
--- a/applications/cli/config/download.properties
+++ b/applications/cli/config/download.properties
@@ -1,8 +1,8 @@
 #Please specify either the version or the full url for the following components
-node.version=9.1.1
-ogmios.version=6.6.1
+node.version=10.1.2
+ogmios.version=6.8.0
 kupo.version=2.9.0
-yaci.store.version=0.1.0-rc5
+yaci.store.version=0.1.0
 
 #node.url=
 #ogmios.url=


### PR DESCRIPTION
Updated node version to 10.1.2, ogmios version to 6.8.0, and yaci.store version to 0.1.0. 