### PR TITLE
Update configurations for GraalVM compatibility

### DIFF
--- a/.github/workflows/dev-release-cli.yml
+++ b/.github/workflows/dev-release-cli.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '21'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: '21.0.2'
+          version: '21.0.5'
           native-image-job-reports: 'true'
       - name: Get Tag from version file
         run: |

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '21'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: '21.0.2'
+          version: '21.0.5'
           native-image-job-reports: 'true'
       - name: Get Tag from version file
         run: |
@@ -31,7 +31,7 @@ jobs:
       - name: Grant execute permission for gradlew
         working-directory: applications/cli
         run: chmod +x gradlew
-      - name: Copy CI specific native-image properties
+      - name: Set OS prefix
         working-directory: applications/cli
         if: runner.os == 'Linux'
         run: |

--- a/applications/cli/Earthfile
+++ b/applications/cli/Earthfile
@@ -50,7 +50,7 @@ docker-build:
     FROM ubuntu:22.04
     ENV JAVA_HOME=/opt/java/openjdk
     ENV STORE_VERSION=0.1.0
-    ENV STORE_NATIVE_BRANCH=feat/graalvm
+    ENV STORE_NATIVE_BRANCH=release/0.2.0-graal-preview1
 
     ARG TARGETOS
     ARG TARGETARCH

--- a/applications/cli/src/main/resources/META-INF/native-image/yaci-cli/native-image.properties
+++ b/applications/cli/src/main/resources/META-INF/native-image/yaci-cli/native-image.properties
@@ -1,4 +1,4 @@
-Args = -H:+StaticExecutableWithDynamicLibC --initialize-at-run-time=io.netty.channel.epoll.Epoll \
+Args = -H:+StaticExecutableWithDynamicLibC -march=compatibility --initialize-at-run-time=io.netty.channel.epoll.Epoll \
 --initialize-at-run-time=io.netty.channel.epoll.Native \
 --initialize-at-run-time=io.netty.channel.epoll.EpollEventLoop \
 --initialize-at-run-time=io.netty.channel.epoll.EpollEventArray \

--- a/applications/cli/src/main/resources/META-INF/native-image/yaci-cli/native-image.properties.ci
+++ b/applications/cli/src/main/resources/META-INF/native-image/yaci-cli/native-image.properties.ci
@@ -1,4 +1,4 @@
-Args = --static --libc=musl --initialize-at-run-time=io.netty.channel.epoll.Epoll \
+Args = --static --libc=musl -march=compatibility --initialize-at-run-time=io.netty.channel.epoll.Epoll \
 --initialize-at-run-time=io.netty.channel.epoll.Native \
 --initialize-at-run-time=io.netty.channel.epoll.EpollEventLoop \
 --initialize-at-run-time=io.netty.channel.epoll.EpollEventArray \


### PR DESCRIPTION
- Added `-march=compatibility` flag to native image properties for enhanced cross-platform compatibility. 
- Updated the GraalVM version from `21.0.2` to `21.0.5` in CI workflows 
- Switched `STORE_NATIVE_BRANCH` to `release/0.2.0-graal-preview1` in Earthfile, aligning with the upcoming release.