### PR TITLE
initial NPM layout

### DIFF
--- a/npm/yaci-devkit-linux-x64/.gitignore
+++ b/npm/yaci-devkit-linux-x64/.gitignore
@@ -1,0 +1,4 @@
+logs/
+yaci-cli.history
+yaci-cli.log
+node_modules/

--- a/npm/yaci-devkit-linux-x64/config/application.properties
+++ b/npm/yaci-devkit-linux-x64/config/application.properties
@@ -1,0 +1,34 @@
+spring.config.import=optional:file:./config/node.properties,optional:file:./config/download.properties
+
+#admin endpoint ports
+server.port=10000
+
+#Set the path to the directory where all yaci-cli related files are stored including cardano-node binary.
+#Default is the user_home/.yaci-cli
+#yaci.cli.home=/Users/satya/yacicli
+
+ogmios.enabled=false
+kupo.enabled=false
+yaci.store.enabled=false
+
+yaci.store.mode=native
+
+bp.create.enabled=true
+
+## Default ports
+#ogmios.port=1337
+#kupo.port=1442
+#yaci.store.port=8080
+#socat.port=3333
+#prometheus.port=12798
+
+
+######################################################
+#To configure an external database for Yaci Store (Indexer),
+# uncomment the following properties and provide the required values
+#Only PostgreSQL is supported for now for external database
+######################################################
+
+#yaci.store.db.url=jdbc:postgresql://localhost:5433/yaci_indexer?currentSchema=dev
+#yaci.store.db.username=user
+#yaci.store.db.password=

--- a/npm/yaci-devkit-linux-x64/config/download.properties
+++ b/npm/yaci-devkit-linux-x64/config/download.properties
@@ -1,0 +1,12 @@
+#Please specify either the version or the full url for the following components
+node.version=10.1.2
+ogmios.version=6.9.0
+kupo.version=2.9.0
+yaci.store.version=0.1.1-graalvm-preview1
+yaci.store.jar.version=0.1.0
+
+#node.url=
+#ogmios.url=
+#kupo.url=
+#yaci.store.url=
+#yaci.store.jar.url=

--- a/npm/yaci-devkit-linux-x64/config/node.properties
+++ b/npm/yaci-devkit-linux-x64/config/node.properties
@@ -1,0 +1,99 @@
+#protocolMagic=42
+#maxKESEvolutions=60
+#securityParam=80
+#slotsPerKESPeriod=129600
+#updateQuorum=1
+#peerSharing=true
+
+## Shelley Genesis
+#maxLovelaceSupply=45000000000000000
+#poolPledgeInfluence=0
+#decentralisationParam=0
+#eMax=18
+#keyDeposit=2000000
+#maxBlockBodySize=65536
+#maxBlockHeaderSize=1100
+#maxTxSize=16384
+#minFeeA=44
+#minFeeB=155381
+#minPoolCost=340000000
+#minUTxOValue=1000000
+#nOpt=100
+#poolDeposit=500000000
+
+#protocolMajorVer=8
+#protocolMinorVer=0
+#monetaryExpansionRate=0.003f
+#treasuryGrowthRate=0.20f
+
+##Default addresses
+#initialAddresses[0].address=addr_test1qzx9hu8j4ah3auytk0mwcupd69hpc52t0cw39a65ndrah86djs784u92a3m5w475w3w35tyd6v3qumkze80j8a6h5tuqq5xe8y
+#initialAddresses[0].balance=450000000
+#initialAddresses[0].staked=true
+#
+#initialAddresses[1].address=addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82
+#initialAddresses[1].balance=250000000
+#initialAddresses[1].staked=false
+
+##Alonzo
+#collateralPercentage=150
+#prMem=5.77e-2
+#prSteps=7.21e-5
+#lovelacePerUTxOWord=34482
+#maxBlockExUnitsMem=62000000
+#maxBlockExUnitsSteps=20000000000
+#maxCollateralInputs=3
+#maxTxExUnitsMem=14000000
+#maxTxExUnitsSteps=10000000000
+#maxValueSize=5000
+
+##Conway
+#pvtcommitteeNormal=0.51f
+#pvtCommitteeNoConfidence=0.51f
+#pvtHardForkInitiation=0.51f
+#pvtMotionNoConfidence=0.51f
+#pvtPPSecurityGroup=0.51f
+
+#dvtMotionNoConfidence=0.51f
+#dvtCommitteeNormal=0.51f
+#dvtCommitteeNoConfidence=0.51f
+#dvtUpdateToConstitution=0.51f
+#dvtHardForkInitiation=0.51f
+#dvtPPNetworkGroup=0.51f
+#dvtPPEconomicGroup=0.51f
+#dvtPPTechnicalGroup=0.51f
+#dvtPPGovGroup=0.51f
+#dvtTreasuryWithdrawal=0.51f
+
+#committeeMinSize=0
+#committeeMaxTermLength=200
+#govActionLifetime=10
+#govActionDeposit=1000000000
+#dRepDeposit=2000000
+#dRepActivity=20
+
+#constitutionScript=7713eb6a46b67bfa1ca082f2b410b0a4e502237d03f7a0b7cbf1b025
+#constitutionUrl=https://devkit.yaci.xyz/constitution.json
+#constitutionDataHash=f89cc2469ce31c3dfda2f3e0b56c5c8b4ee4f0e5f66c30a3f12a95298b01179e
+
+## CC Members
+#ccMembers[0].hash=scriptHash-8fc13431159fdda66347a38c55105d50d77d67abc1c368b876d52ad1
+#ccMembers[0].term=340
+
+########################################################################################################
+# Workaround for : https://github.com/bloxbean/yaci-devkit/issues/65
+#
+# The following parameters are enabled for a V2 cost model-related issue where there are 10 extra elements if the devnet
+# is started with the Conway era at epoch 0. The following parameters are enabled to configure the Conway era hard fork (HF) at epoch 1.
+# The network will start in the Babbage era and then hard fork (HF) to the Conway era at epoch 1.
+
+# The shiftStartTimeBehind=true flag is enabled to shift the start time of the network to a time behind the current time by adjusting security parameter
+# which changes the stability window. This is to speed up the process of reaching the Conway era.
+#
+# This should only be done in a development environment because if the stability window is larger than the epoch length, the reward/treasury calculations will be incorrect or ignored.
+# Therefore, for a real multi-node network, you should start the network at the current time and allow it to reach the Conway era at epoch 1.
+# So, the shiftStartTimeBehind flag should be "false" for non-development / multi-node networks.
+#
+#########################################################################################################
+conwayHardForkAtEpoch=1
+shiftStartTimeBehind=true

--- a/npm/yaci-devkit-linux-x64/package.json
+++ b/npm/yaci-devkit-linux-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@bloxbean/yaci-devkit-linux-x64",
+  "version": "0.10.0",
+  "main": "yaci-cli",
+  "files": [
+    "yaci-cli",
+    "config"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 12"
+  },
+  "bin": {
+    "yaci-devkit-linux-x64": "./yaci-cli"
+  },
+  "repository": "github:bloxbean/yaci-devkit"
+}

--- a/npm/yaci-devkit/.gitignore
+++ b/npm/yaci-devkit/.gitignore
@@ -1,0 +1,4 @@
+logs/
+yaci-cli.history
+yaci-cli.log
+node_modules/

--- a/npm/yaci-devkit/README.md
+++ b/npm/yaci-devkit/README.md
@@ -1,0 +1,3 @@
+# Yaci Devkit
+
+Run `npx yaci-devkit` to start. See [here](https://github.com/bloxbean/yaci-devkit/tree/main/applications/cli#how-to-use-) for docs

--- a/npm/yaci-devkit/package-lock.json
+++ b/npm/yaci-devkit/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "@bloxbean/yaci-devkit",
+  "version": "0.10.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bloxbean/yaci-devkit",
+      "version": "0.10.0",
+      "license": "MIT",
+      "dependencies": {
+        "@bloxbean/yaci-devkit-linux-x64": "file:../yaci-devkit-linux-x64"
+      },
+      "bin": {
+        "yaci-devkit-foo": "index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "typescript": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "../yaci-devkit-linux-x64": {
+      "version": "0.10.0",
+      "license": "MIT",
+      "bin": {
+        "yaci-devkit-linux-x64": "yaci-cli"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@bloxbean/yaci-devkit-linux-x64": {
+      "resolved": "../yaci-devkit-linux-x64",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/npm/yaci-devkit/package.json
+++ b/npm/yaci-devkit/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@bloxbean/yaci-devkit",
+  "version": "0.10.0",
+  "engines": {
+    "node": ">=20.8.0"
+  },
+  "license": "MIT",
+  "repository": "github:bloxbean/yaci-devkit",
+  "bin": {
+    "yaci-devkit": "./start.mjs"
+  },
+  "dependencies": {
+    "@bloxbean/yaci-devkit-linux-x64": "file:../yaci-devkit-linux-x64"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": ">=5.0.0"
+  }
+}

--- a/npm/yaci-devkit/start.mjs
+++ b/npm/yaci-devkit/start.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+import { fileURLToPath } from 'node:url';
+
+const osType = platform();
+
+
+/**
+ * Find the script for the corresponding os-specific package.
+ * 
+ * Note: it's tempting to solve this in a few ways that are actually bad:
+ * 1. Call `npx <package> <script>` on the corresponding package.
+ *    This is bad as there are package managers other than npm
+ * 2. Try to compute the path for the package manually.
+ *    This is bad as different package managers & runtimes have different folder structures for dependencies
+ * 
+ * Instead, we use `import.meta.resolve` which returns the path to the `main` entry in `package.json`.
+ * Conveniently, we've made the `main` in the packages point directly to the yaci-cli 
+ * 
+ * @return {Record<string, () => string}
+ */
+const packageMap = {
+    // darwin: () => import.meta.resolve("@bloxbean/yaci-devkit-macos-arm64"),
+    linux: () => import.meta.resolve("@bloxbean/yaci-devkit-linux-x64"),
+};
+
+if (packageMap[osType] == null) {
+    console.error(`Unsupported platform: ${osType}`);
+    process.exit(1);
+}
+const binPath = fileURLToPath(packageMap[osType]());
+
+const child = spawn(binPath, [...process.argv.slice(2)], {
+    stdio: "inherit",
+});
+
+child.on("close", (code) => {
+    process.exit(code ?? 0);
+});

--- a/npm/yaci-devkit/tsconfig.json
+++ b/npm/yaci-devkit/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "allowJs": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src/**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR sets up the initial layout for #68 

With this PR, you can run `npx yaci-devkit` and it automatically works (even if you don't have the NPM package installed on your machine)

The NPM folder has two top-level items:
1. `yaci-devkit-linux-x64` (which should be mostly code-generated)
2. `yaci-devkit` (which aggregates all the builds)

See inline comments in this PR for more details