### PR TITLE
Changes in default genesis files for Dolos compatibility

### DIFF
--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/ClusterService.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/ClusterService.java
@@ -308,8 +308,14 @@ public class ClusterService {
             privNetService.setupNewKeysAndDefaultPool(clusterFolder, clusterName, clusterInfo, genesisConfigCopy, activeSlotsCoeff, writer);
         }
 
+        String slotLengthStr;
+        if ((int)slotLength == slotLength)
+            slotLengthStr = String.valueOf((int)slotLength);
+        else
+            slotLengthStr = String.valueOf(slotLength);
+
         Map values = genesisConfigCopy.getConfigMap();
-        values.put("slotLength", String.valueOf(slotLength));
+        values.put("slotLength", String.valueOf(slotLengthStr));
         values.put("activeSlotsCoeff", String.valueOf(activeSlotsCoeff));
         values.put("epochLength", String.valueOf(epochLength));
 

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfig.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfig.java
@@ -61,8 +61,10 @@ public class GenesisConfig {
 
     //Alonzo
     private int collateralPercentage = 150;
-    private String prMem = "5.77e-2";
-    private String prSteps = "7.21e-5";
+    private String prMemNumerator = "577";
+    private String prMemDenominator ="10000";
+    private String prStepsNumerator = "721";
+    private String prStepsDenominator ="10000000";
     private long lovelacePerUTxOWord = 34482;
     private long maxBlockExUnitsMem = 62000000;
     private long maxBlockExUnitsSteps = 20000000000L;
@@ -292,8 +294,10 @@ public class GenesisConfig {
         map.put("defaultDelegators", defaultDelegators);
 
         map.put("collateralPercentage", collateralPercentage);
-        map.put("prMem", prMem);
-        map.put("prSteps", prSteps);
+        map.put("prMemNumerator", prMemNumerator);
+        map.put("prMemDenominator", prMemDenominator);
+        map.put("prStepsNumerator", prStepsNumerator);
+        map.put("prStepsDenominator", prStepsDenominator);
         map.put("lovelacePerUTxOWord", lovelacePerUTxOWord);
         map.put("maxBlockExUnitsMem", maxBlockExUnitsMem);
         map.put("maxBlockExUnitsSteps", maxBlockExUnitsSteps);
@@ -385,8 +389,10 @@ public class GenesisConfig {
         genesisConfig.setDefaultDelegators(new ArrayList<>(defaultDelegators));
 
         genesisConfig.setCollateralPercentage(collateralPercentage);
-        genesisConfig.setPrMem(prMem);
-        genesisConfig.setPrSteps(prSteps);
+        genesisConfig.setPrMemNumerator(prMemNumerator);
+        genesisConfig.setPrMemDenominator(prMemDenominator);
+        genesisConfig.setPrStepsNumerator(prStepsNumerator);
+        genesisConfig.setPrStepsDenominator(prStepsDenominator);
         genesisConfig.setLovelacePerUTxOWord(lovelacePerUTxOWord);
         genesisConfig.setMaxBlockExUnitsMem(maxBlockExUnitsMem);
         genesisConfig.setMaxBlockExUnitsSteps(maxBlockExUnitsSteps);

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfig.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfig.java
@@ -101,7 +101,9 @@ public class GenesisConfig {
 
     private String constitutionUrl = "https://devkit.yaci.xyz/constitution.json";
     private String constitutionDataHash = "f89cc2469ce31c3dfda2f3e0b56c5c8b4ee4f0e5f66c30a3f12a95298b01179e";
-    private String constitutionScript;
+
+    //Always true script V3. Cbor hex: 46450101002499
+    private String constitutionScript = "186e32faa80a26810392fda6d559c7ed4721a65ce1c9d4ef3e1c87b4";
 
     private List<CCMember> ccMembers = new ArrayList<>();
     private int ccThresholdNumerator = 2;

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/profiles/GenesisProfile.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/profiles/GenesisProfile.java
@@ -23,8 +23,10 @@ public enum GenesisProfile {
     private static GenesisConfig zeroFeeGenesisProfile(GenesisConfig genesisConfig) {
         genesisConfig.setMinFeeA(0);
         genesisConfig.setMinFeeB(0);
-        genesisConfig.setPrMem("0");
-        genesisConfig.setPrSteps("0");
+        genesisConfig.setPrMemNumerator("0");
+        genesisConfig.setPrMemDenominator("1");
+        genesisConfig.setPrStepsNumerator("0");
+        genesisConfig.setPrStepsDenominator("1");
         genesisConfig.setLovelacePerUTxOWord(0);
 
         return genesisConfig;

--- a/applications/cli/src/main/resources/localcluster/templates/devnet/genesis-templates/alonzo-genesis.json
+++ b/applications/cli/src/main/resources/localcluster/templates/devnet/genesis-templates/alonzo-genesis.json
@@ -348,8 +348,14 @@
     ]
   },
     "executionPrices": {
-        "prMem": {{prMem}},
-        "prSteps": {{prSteps}}
+        "prSteps": {
+            "numerator" :   {{prStepsNumerator}},
+            "denominator" : {{prStepsDenominator}}
+        },
+        "prMem": {
+            "numerator" :   {{prMemNumerator}},
+            "denominator" : {{prMemDenominator}}
+        }
     },
     "lovelacePerUTxOWord": {{lovelacePerUTxOWord}},
     "maxBlockExUnits": {


### PR DESCRIPTION
#86 

1.  Use slotLength as int value instead of double
2. Use fraction structure for executionPrices
3. Add alwaysTrue V3 script as default constitution script
