### PR TITLE
Kill any previously running processes before starting yaci-cli.

### DIFF
--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/YaciCliApplication.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/YaciCliApplication.java
@@ -1,8 +1,11 @@
 package com.bloxbean.cardano.yacicli;
 
 import com.bloxbean.cardano.yacicli.localcluster.config.GenesisConfig;
+import com.bloxbean.cardano.yacicli.util.ProcessUtil;
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -11,12 +14,19 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 @EnableConfigurationProperties(GenesisConfig.class)
 @Slf4j
 public class YaciCliApplication {
+    @Autowired
+    private ProcessUtil processUtil;
 
 	public static void main(String[] args) {
 		new SpringApplicationBuilder(YaciCliApplication.class)
 				.logStartupInfo(false)
 				.run(args);
 	}
+
+    @PostConstruct
+    public void stopRunningProcesses() {
+        processUtil.killRunningProcesses();
+    }
 
     @PreDestroy
     public void onShutDown() {

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/util/ProcessUtil.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/util/ProcessUtil.java
@@ -1,10 +1,17 @@
 package com.bloxbean.cardano.yacicli.util;
 
 import com.bloxbean.cardano.yacicli.commands.common.ExecutorHelper;
+import com.bloxbean.cardano.yacicli.localcluster.ClusterConfig;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -16,6 +23,7 @@ import static com.bloxbean.cardano.yacicli.util.ConsoleWriter.*;
 @RequiredArgsConstructor
 public class ProcessUtil {
     private final ExecutorHelper executorHelper;
+    private final ClusterConfig clusterConfig;
 
     public boolean executeAndFinish(ProcessBuilder processBuilder, String scriptPurpose, Consumer<String> writer) {
         try {
@@ -75,9 +83,119 @@ public class ProcessUtil {
             return null;
         }
 
+        createProcessId(processName, process);
+
         //stop consuming error stream
         errorStream.stop();
         return process;
     }
 
+    public String createProcessId(String processName, Process process) {
+        try {
+            var yaciCliHome = clusterConfig.getYaciCliHome();
+            // Validate the yaciCliHome directory
+            Path homePath = Paths.get(yaciCliHome);
+            if (!Files.exists(homePath)) {
+                writeLn(error("yaci-cli home directory does not exist: " + yaciCliHome));
+                return null;
+            }
+
+            if (!Files.isDirectory(homePath)) {
+                writeLn(error("yaci-cli home path is not a directory: " + yaciCliHome));
+                return null;
+            }
+
+            Path pids = homePath.resolve("pids");
+            if (!Files.exists(pids))
+                pids.toFile().mkdirs();
+
+            Path pidFilePath = pids.resolve(processName + ".pid");
+            long pid = process.pid();
+            Files.writeString(pidFilePath, String.valueOf(pid));
+
+            // Return the full path to the created PID file as a string
+            return pidFilePath.toString();
+        } catch (IOException e) {
+            writeLn(error("Failed to create the PID file: " + e.getMessage()));
+            return null;
+        }
+    }
+
+    public void deletePidFile(String processName) {
+        var yaciCliHome = clusterConfig.getYaciCliHome();
+        // Validate the yaciCliHome directory
+        Path homePath = Paths.get(yaciCliHome);
+        Path pids = homePath.resolve("pids");
+
+        var pidPath = pids.resolve(processName + ".pid");
+        if (Files.exists(pidPath)) {
+            pidPath.toFile().delete();
+            writeLn(info("Deleted pid file : " + processName + ".pid"));
+        }
+    }
+
+    public void killRunningProcesses() {
+        var yaciCliHome = clusterConfig.getYaciCliHome();
+
+        // Validate the yaciCliHome directory
+        Path homePath = Paths.get(yaciCliHome);
+        if (!Files.exists(homePath)) {
+            writeLn(error("The yaciCliHome directory does not exist: " + yaciCliHome));
+            return;
+        }
+        if (!Files.isDirectory(homePath)) {
+            writeLn(error("The yaciCliHome path is not a directory: " + yaciCliHome));
+            return;
+        }
+
+        // Resolve the pids directory
+        Path pidsDir = homePath.resolve("pids");
+        if (!Files.exists(pidsDir) || !Files.isDirectory(pidsDir)) {
+            writeLn(error("The pids directory does not exist or is not a directory: " + pidsDir));
+            return;
+        }
+
+        List<Long> pidList = new ArrayList<>();
+        try (DirectoryStream<Path> pidFiles = Files.newDirectoryStream(pidsDir, "*.pid")) {
+            for (Path pidFile : pidFiles) {
+                try {
+                    // Read the PID from the file
+                    String pidString = Files.readString(pidFile).trim();
+                    if (!pidString.isEmpty()) {
+                        pidList.add(Long.parseLong(pidString));
+                    }
+                } catch (IOException | NumberFormatException e) {
+                    writeLn(error("Failed to read or parse PID file: " + pidFile + " - " + e.getMessage()));
+                }
+            }
+        } catch (IOException e) {
+            writeLn(error("Failed to list PID files in directory: " + pidsDir + " : " + e.getMessage()));
+            return;
+        }
+
+        var deletedPids = new ArrayList<>();
+        for (Long pid : pidList) {
+            try {
+                ProcessHandle.of(pid)
+                                .ifPresent(processHandle -> {
+                                    processHandle.descendants().forEach(ph -> {
+                                        deletedPids.add(ph.pid());
+                                        ph.destroyForcibly();
+                                    });
+                                    var result = processHandle.destroyForcibly();
+                                    if (!result) {
+                                        writeLn(error("Failed to kill process with PID : " + pid));
+                                    } else {
+                                        deletedPids.add(processHandle.pid());
+                                    }
+                                });
+            } catch (Exception e) {
+                writeLn(error("Failed to kill process with PID: " + pid + " - " + e.getMessage()));
+            }
+        }
+
+        if (!deletedPids.isEmpty()) {
+            writeLn(info("Found existing processes. Killed processes with pids: " + deletedPids));
+        }
+    }
 }

--- a/config/version
+++ b/config/version
@@ -1,2 +1,2 @@
-tag=0.10.0-preview4
+tag=0.10.0-preview5
 revision=

--- a/npm/yaci-devkit/package-lock.json
+++ b/npm/yaci-devkit/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bloxbean/yaci-devkit",
-  "version": "0.10.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bloxbean/yaci-devkit",
-      "version": "0.10.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@bloxbean/yaci-devkit-linux-x64": "file:../yaci-devkit-linux-x64",
-        "@bloxbean/yaci-devkit-macos-arm64": "file:../yaci-devkit-macos-arm64"
+        "@bloxbean/yaci-devkit-linux-x64": "0.0.1",
+        "@bloxbean/yaci-devkit-macos-arm64": "0.0.1"
       },
       "bin": {
         "yaci-devkit": "start.mjs"
@@ -25,7 +25,7 @@
     },
     "../yaci-devkit-linux-x64": {
       "name": "@bloxbean/yaci-devkit-linux-x64",
-      "version": "0.10.0",
+      "version": "0.0.1",
       "license": "MIT",
       "bin": {
         "yaci-devkit-linux-x64": "yaci-cli"
@@ -36,7 +36,7 @@
     },
     "../yaci-devkit-macos-arm64": {
       "name": "@bloxbean/yaci-devkit-macos-arm64",
-      "version": "0.10.0",
+      "version": "0.0.1",
       "license": "MIT",
       "bin": {
         "yaci-devkit-linux-x64": "yaci-cli"


### PR DESCRIPTION
To fix #94 

- Create process-specific PID files.
- During yaci-cli startup, if any PID file exists, kill the process with the corresponding PID.
- Handle yaci-cli process cleanup in start.js for the npm distribution.