### PR TITLE
Chore: use `env` in `devkit.sh` shebang

### DIFF
--- a/bin/devkit.sh
+++ b/bin/devkit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
This improved portability, particularly, makes it run on NixOS. 