### PR TITLE
Switch all scripts to portable shebangs

### DIFF
--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Function to check if a command exists
 command_exists() {

--- a/scripts/cardano-cli.sh
+++ b/scripts/cardano-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 

--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 

--- a/scripts/ssh.sh
+++ b/scripts/ssh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 

--- a/scripts/yaci-cli.sh
+++ b/scripts/yaci-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
Not everyone has bash installed at /bin/bash; the more portable shebang is to use `/usr/bin/env bash`, which will locate where bash is installed on the users system.

For example, this enables yaci-devkit for users on NixOS.