### PR TITLE
fix(npm): Update child process to inherit environment variables

### DIFF
--- a/npm/yaci-devkit/start.mjs
+++ b/npm/yaci-devkit/start.mjs
@@ -88,6 +88,7 @@ const additionalConfigArg = "-Dspring.config.import=" + additionalConfig;
 const child = spawn(binPath, [additionalConfigArg, ...process.argv.slice(2)], {
     stdio: "inherit",
     env: {
+        ...process.env // Inherit parent environment. Additional env vars below.
         // YACI_CLI_HOME: yaciCLIHome
     },
 


### PR DESCRIPTION
Fixes #171 

Inherit parent environment variables in the child process. 

This is the default behavior that was lost when `env` was specified for the child process. I just recuped it without closing the possibility of adding more env vars