### PR TITLE
 Fix npm publishing CI and native wallet signing

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -15,7 +15,6 @@ jobs:
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       FORCE_COLOR: 1
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +70,9 @@ jobs:
 
   npm-publish:
     needs: buildAndPush
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         os: [ "ubuntu-22.04", "macos-14" ]
@@ -81,8 +83,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
 
       - name: Get Tag from version file
         run: |
@@ -113,14 +118,8 @@ jobs:
         working-directory: npm/${{ env.npm_folder }}
         run: npm version ${{ env.TAG }} --no-git-tag-version
 
-      - name: Configure npm for scoped package
-        run: |
-          echo "@my-org:registry=https://registry.npmjs.org/" >> ~/.npmrc  
-
       - name: Publish to npm
         working-directory: npm/${{ env.npm_folder }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [[ "${{ env.TAG }}" == *"-preview"* ]]; then            
             npm publish --access public --tag preview
@@ -133,12 +132,18 @@ jobs:
   publish-yaci-devkit:
     needs: npm-publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
 
       - name: Get Tag from version file
         run: |
@@ -156,8 +161,6 @@ jobs:
 
       - name: Publish `yaci-devkit` to npm
         working-directory: npm/yaci-devkit
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [[ "${{ env.TAG }}" == *"-preview"* ]]; then            
             npm publish --access public --tag preview

--- a/.github/workflows/release-viewer.yml
+++ b/.github/workflows/release-viewer.yml
@@ -8,14 +8,20 @@ on:
 jobs:
   npm-publish:
     runs-on: "ubuntu-22.04"
+    permissions:
+      contents: read
+      id-token: write
     env:
       FORCE_COLOR: 1
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
 
       - name: Get Tag from version file
         run: |
@@ -26,10 +32,6 @@ jobs:
         working-directory: applications/viewer
         run: npm version ${{ env.TAG }} --no-git-tag-version
 
-      - name: Configure npm for scoped package
-        run: |
-          echo "@my-org:registry=https://registry.npmjs.org/" >> ~/.npmrc
-
       - name: NPM Build
         working-directory: applications/viewer
         run: |
@@ -38,8 +40,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: applications/viewer
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [[ "${{ env.TAG }}" == *"-preview"* ]]; then            
             npm publish --access public --tag preview

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/cip30/controller/WalletApiController.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/cip30/controller/WalletApiController.java
@@ -180,18 +180,16 @@ public class WalletApiController {
             }
     )
     @PostMapping("/sign-tx")
-    public ResponseEntity<?> signTransaction(@Valid @RequestBody SignTxRequest request) {
+    public ResponseEntity<SignTxResponse> signTransaction(@Valid @RequestBody SignTxRequest request) {
         Optional<SignTxResponse> response = walletSigningService.signTransaction(
                 request.getTxCbor(),
                 request.getAccountId()
         );
 
         return response
-                .<ResponseEntity<?>>map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.badRequest().body(Map.of(
-                        "code", 1,
-                        "info", "Failed to sign transaction. Account not found or signing error."
-                )));
+                .map(ResponseEntity::ok)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Failed to sign transaction. Account not found or signing error."));
     }
 
     @Operation(
@@ -208,7 +206,7 @@ public class WalletApiController {
             }
     )
     @PostMapping("/sign-data")
-    public ResponseEntity<?> signData(@Valid @RequestBody SignDataRequest request) {
+    public ResponseEntity<SignDataResponse> signData(@Valid @RequestBody SignDataRequest request) {
         Optional<SignDataResponse> response = walletSigningService.signData(
                 request.getPayload(),
                 request.getAddress(),
@@ -216,11 +214,9 @@ public class WalletApiController {
         );
 
         return response
-                .<ResponseEntity<?>>map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.badRequest().body(Map.of(
-                        "code", 1,
-                        "info", "Failed to sign data. Account not found or signing error."
-                )));
+                .map(ResponseEntity::ok)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Failed to sign data. Account not found or signing error."));
     }
 
     @Operation(

--- a/applications/cli/src/test/java/com/bloxbean/cardano/yacicli/cip30/controller/WalletApiControllerTest.java
+++ b/applications/cli/src/test/java/com/bloxbean/cardano/yacicli/cip30/controller/WalletApiControllerTest.java
@@ -1,0 +1,102 @@
+package com.bloxbean.cardano.yacicli.cip30.controller;
+
+import com.bloxbean.cardano.yacicli.cip30.dto.SignDataResponse;
+import com.bloxbean.cardano.yacicli.cip30.dto.SignTxResponse;
+import com.bloxbean.cardano.yacicli.cip30.service.Cip30Service;
+import com.bloxbean.cardano.yacicli.cip30.service.TransferService;
+import com.bloxbean.cardano.yacicli.cip30.service.WalletAccountService;
+import com.bloxbean.cardano.yacicli.cip30.service.WalletSigningService;
+import com.bloxbean.cardano.yacicli.localcluster.ClusterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class WalletApiControllerTest {
+    private WalletSigningService walletSigningService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        walletSigningService = mock(WalletSigningService.class);
+
+        WalletApiController controller = new WalletApiController(
+                mock(WalletAccountService.class),
+                walletSigningService,
+                mock(TransferService.class),
+                mock(Cip30Service.class),
+                mock(ClusterService.class));
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void signTransactionReturnsConcreteJsonResponse() throws Exception {
+        when(walletSigningService.signTransaction(eq("84a0"), eq("0")))
+                .thenReturn(Optional.of(SignTxResponse.builder()
+                        .witnessSet("a100")
+                        .txHash("abcd")
+                        .build()));
+
+        mockMvc.perform(post("/api/v1/wallet/sign-tx")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"txCbor":"84a0","accountId":"0","partialSign":false}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.witnessSet").value("a100"))
+                .andExpect(jsonPath("$.txHash").value("abcd"));
+    }
+
+    @Test
+    void signDataReturnsConcreteJsonResponse() throws Exception {
+        when(walletSigningService.signData(eq("48656c6c6f"), eq("00"), eq("0")))
+                .thenReturn(Optional.of(SignDataResponse.builder()
+                        .signature("8458")
+                        .key("a401")
+                        .build()));
+
+        mockMvc.perform(post("/api/v1/wallet/sign-data")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"address":"00","payload":"48656c6c6f","accountId":"0"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.signature").value("8458"))
+                .andExpect(jsonPath("$.key").value("a401"));
+    }
+
+    @Test
+    void signDataFailureReturnsBadRequest() throws Exception {
+        when(walletSigningService.signData(eq("48656c6c6f"), eq("00"), eq("0")))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/v1/wallet/sign-data")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"address":"00","payload":"48656c6c6f","accountId":"0"}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message", containsString("Failed to sign data")));
+    }
+}

--- a/applications/viewer/src/routes/adapot/list/+page.server.ts
+++ b/applications/viewer/src/routes/adapot/list/+page.server.ts
@@ -1,0 +1,78 @@
+import type { PageServerLoad } from './$types';
+import { env } from '$env/dynamic/public';
+
+interface ApiResponse {
+    epoch: number;
+    rewards_pot: number | null;
+    deposits_stake: number | null;
+    fees: number | null;
+    treasury: number | null;
+    reserves: number | null;
+    circulation: number | null;
+    distributed_rewards: number | null;
+    undistributed_rewards: number | null;
+    pool_rewards_pot: number | null;
+}
+
+function numberOrZero(value: number | null | undefined): number {
+    return value ?? 0;
+}
+
+function mapAdapot(item: ApiResponse) {
+    return {
+        epoch: item.epoch,
+        totalAmount: numberOrZero(item.rewards_pot),
+        currentEpoch: item.epoch,
+        details: {
+            depositsStake: numberOrZero(item.deposits_stake),
+            fees: numberOrZero(item.fees),
+            treasury: numberOrZero(item.treasury),
+            reserves: numberOrZero(item.reserves),
+            circulation: numberOrZero(item.circulation),
+            distributedRewards: numberOrZero(item.distributed_rewards),
+            undistributedRewards: numberOrZero(item.undistributed_rewards),
+            poolRewardsPot: numberOrZero(item.pool_rewards_pot)
+        }
+    };
+}
+
+export const load: PageServerLoad = async ({ url, fetch }) => {
+    const page = url.searchParams.get('page') || '1';
+    const count = url.searchParams.get('count') || '15';
+
+    try {
+        const INDEXER_BASE_URL = env.PUBLIC_INDEXER_BASE_URL;
+        if (!INDEXER_BASE_URL) {
+            throw new Error('PUBLIC_INDEXER_BASE_URL environment variable is not set');
+        }
+
+        const params = new URLSearchParams({ page, count });
+        const response = await fetch(`${INDEXER_BASE_URL}/adapot/list?${params.toString()}`);
+
+        if (response.status === 404) {
+            return { adapots: [], page, count };
+        }
+        if (!response.ok) {
+            throw new Error(`Failed to fetch AdaPot list (Status: ${response.status})`);
+        }
+
+        const adapots: ApiResponse[] = await response.json();
+        if (!Array.isArray(adapots)) {
+            throw new Error('Invalid data format received from server');
+        }
+
+        return {
+            adapots: adapots.map(mapAdapot),
+            page,
+            count
+        };
+    } catch (error) {
+        console.error('Error loading AdaPots:', error);
+        return {
+            adapots: [],
+            page,
+            count,
+            error: error instanceof Error ? error.message : 'An error occurred while loading AdaPots'
+        };
+    }
+};

--- a/applications/viewer/src/routes/governance/proposals/+page.server.ts
+++ b/applications/viewer/src/routes/governance/proposals/+page.server.ts
@@ -1,0 +1,42 @@
+import type { PageServerLoad } from './$types';
+import { env } from '$env/dynamic/public';
+import type { Proposal } from './types';
+
+export const load: PageServerLoad = async ({ url }) => {
+    const page = url.searchParams.get('page') || '1';
+    const count = url.searchParams.get('count') || '10';
+    const order = url.searchParams.get('order') || 'desc';
+
+    try {
+        const INDEXER_BASE_URL = env.PUBLIC_INDEXER_BASE_URL;
+        if (!INDEXER_BASE_URL) {
+            throw new Error('PUBLIC_INDEXER_BASE_URL environment variable is not set');
+        }
+
+        const response = await fetch(`${INDEXER_BASE_URL}/governance-state/proposals?page=${page}&count=${count}&order=${order}`);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch proposals (Status: ${response.status})`);
+        }
+
+        const proposals: Proposal[] = await response.json();
+        if (!Array.isArray(proposals)) {
+            throw new Error('Invalid data format received from server');
+        }
+
+        return {
+            proposals,
+            page,
+            count,
+            order
+        };
+    } catch (error) {
+        console.error('Error loading proposals:', error);
+        return {
+            proposals: [],
+            page,
+            count,
+            order,
+            error: error instanceof Error ? error.message : 'An error occurred while loading proposals'
+        };
+    }
+};

--- a/config/version
+++ b/config/version
@@ -1,2 +1,2 @@
-tag=0.12.0-ci2-beta1
+tag=0.12.0-preview1
 revision=

--- a/config/version
+++ b/config/version
@@ -1,2 +1,2 @@
-tag=0.12.0-beta1-ci1
+tag=0.12.0-ci1-beta1
 revision=

--- a/config/version
+++ b/config/version
@@ -1,2 +1,2 @@
-tag=0.12.0-beta1
+tag=0.12.0-beta1-ci1
 revision=

--- a/config/version
+++ b/config/version
@@ -1,2 +1,2 @@
-tag=0.12.0-preview1
+tag=0.12.0-beta1
 revision=

--- a/config/version
+++ b/config/version
@@ -1,2 +1,2 @@
-tag=0.12.0-ci1-beta1
+tag=0.12.0-ci2-beta1
 revision=

--- a/npm/yaci-devkit/start.mjs
+++ b/npm/yaci-devkit/start.mjs
@@ -84,8 +84,9 @@ const additionalConfig = "optional:file:" + configPath + "/application.propertie
     + "optional:file:" + configPath + "/node.properties"
 
 const additionalConfigArg = "-Dspring.config.import=" + additionalConfig;
+const costModelsPathArg = "-Dyaci.cli.plutus-costmodels-path=" + configPath;
 
-const child = spawn(binPath, [additionalConfigArg, ...process.argv.slice(2)], {
+const child = spawn(binPath, [additionalConfigArg, costModelsPathArg, ...process.argv.slice(2)], {
     stdio: "inherit",
     env: {
         // YACI_CLI_HOME: yaciCLIHome


### PR DESCRIPTION
 ## Summary
  - Update CLI/viewer npm release workflows for trusted publishing
  - Use Node 24/latest npm and remove `NPM_TOKEN` publishing flow
  - Pass the Plutus cost model path through the npm devkit launcher
  - Add viewer server loads for AdaPot history and governance proposals
  - Fix native Docker CIP-30 `sign-tx` / `sign-data` JSON responses
  - Add controller tests for wallet signing responses and failure handling

  ## Why
  This branch fixes npm publishing setup and the npm launcher cost model path, while also addressing the native Docker wallet signing failure where successful signing responses returned `500 No acceptable representation`.
