### PR TITLE
Slot leader time travel below f1

### DIFF
--- a/applications/cli/config/application.properties
+++ b/applications/cli/config/application.properties
@@ -28,6 +28,12 @@ bp.create.enabled=true
 #yano.server.port=14447
 #yano.http.port=6060
 
+## Whether Yano's past-time-travel backfill runs Praos slot-leader checks, placing blocks only in
+## VRF-eligible slots. auto (default): on when a Haskell node validates the chain (companion, yano-primary)
+## and activeSlotsCoeff is below 1 (block time longer than slot length), and for local multi-node devnets.
+## A Haskell relay rejects a dense backfill at activeSlotsCoeff below 1 with VRFLeaderValueTooBig.
+#yano.past.time.travel.slot.leader.mode=auto
+
 
 ######################################################
 #To configure an external database for Yaci Store (Indexer),

--- a/applications/cli/config/node.properties
+++ b/applications/cli/config/node.properties
@@ -10,6 +10,10 @@ nodeMode=companion
 #updateQuorum=1
 #peerSharing=true
 
+## Node log tracing of the chain-sync client. On by default so a bootstrap chain the node rejects
+## (for example VRFLeaderValueTooBig at activeSlotsCoeff below 1) shows up in the node log.
+#traceChainSyncClient=true
+
 ## Shelley Genesis
 #maxLovelaceSupply=45000000000000000
 #poolPledgeInfluence=0

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfig.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfig.java
@@ -22,6 +22,9 @@ public class GenesisConfig {
     private long slotsPerKESPeriod = 129600;
     private int updateQuorum = 1;
     private boolean peerSharing = true;
+    // Node config TraceChainSyncClient. On by default so a bootstrap chain the node rejects
+    // (for example VRFLeaderValueTooBig at activeSlotsCoeff below 1) shows up in the node log.
+    private boolean traceChainSyncClient = true;
 
     private String genesisUtxoSupply = "30000000000000000"; //In byron genesis
     private int nGenesisKeys = 3; //For new priv network
@@ -360,6 +363,7 @@ public class GenesisConfig {
         map.put("slotsPerKESPeriod", slotsPerKESPeriod);
         map.put("updateQuorum", updateQuorum);
         map.put("peerSharing", peerSharing);
+        map.put("traceChainSyncClient", traceChainSyncClient);
         map.put("genesisUtxoSupply", genesisUtxoSupply);
         map.put("nGenesisKeys", nGenesisKeys);
         map.put("nGenesisUtxoKeys", nGenesisUtxoKeys);
@@ -467,6 +471,7 @@ public class GenesisConfig {
         genesisConfig.setSlotsPerKESPeriod(slotsPerKESPeriod);
         genesisConfig.setUpdateQuorum(updateQuorum);
         genesisConfig.setPeerSharing(peerSharing);
+        genesisConfig.setTraceChainSyncClient(traceChainSyncClient);
         genesisConfig.setGenesisUtxoSupply(genesisUtxoSupply);
         genesisConfig.setNGenesisKeys(nGenesisKeys);
         genesisConfig.setNGenesisUtxoKeys(nGenesisUtxoKeys);
@@ -572,6 +577,8 @@ public class GenesisConfig {
                 updateQuorum = Integer.parseInt(updatedValues.get("updateQuorum"));
             if (updatedValues.get("peerSharing") != null && !updatedValues.get("peerSharing").isEmpty())
                 peerSharing = Boolean.parseBoolean(updatedValues.get("peerSharing"));
+            if (updatedValues.get("traceChainSyncClient") != null && !updatedValues.get("traceChainSyncClient").isEmpty())
+                traceChainSyncClient = Boolean.parseBoolean(updatedValues.get("traceChainSyncClient"));
             if (updatedValues.get("genesisUtxoSupply") != null && !updatedValues.get("genesisUtxoSupply").isEmpty())
                 genesisUtxoSupply = updatedValues.get("genesisUtxoSupply");
             if (updatedValues.get("nGenesisKeys") != null && !updatedValues.get("nGenesisKeys").isEmpty())

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/yano/YanoConfigBuilder.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/yano/YanoConfigBuilder.java
@@ -35,10 +35,12 @@ public class YanoConfigBuilder {
      * @param yanoConfigDir resolved path to Yano's devnet config (genesis files, keys)
      * @param yanoDataDir   resolved path for Yano's chainstate storage
      * @param pastTimeTravelMode whether past-time-travel mode is enabled
+     * @param slotLeaderTimeTravel whether the past-time-travel backfill runs Praos slot-leader checks
+     *                             (see {@link YanoService#slotLeaderTimeTravelEnabled(ClusterInfo)})
      * @return true if config was written successfully
      */
     public boolean build(ClusterInfo clusterInfo, Path yanoConfigDir, Path yanoDataDir,
-                         boolean pastTimeTravelMode) {
+                         boolean pastTimeTravelMode, boolean slotLeaderTimeTravel) {
         Map<String, String> props = new LinkedHashMap<>();
 
         // Quarkus profile
@@ -67,7 +69,7 @@ public class YanoConfigBuilder {
         // Past-time-travel mode
         if (pastTimeTravelMode) {
             props.put("yano.block-producer.past-time-travel-mode", "true");
-            if (clusterInfo.isLocalMultiNodeEnabled()) {
+            if (slotLeaderTimeTravel) {
                 props.put("yano.block-producer.past-time-travel-slot-leader-mode", "true");
             }
         }

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/yano/YanoService.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/yano/YanoService.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yacicli.localcluster.yano;
 
 import com.bloxbean.cardano.yacicli.localcluster.ClusterConfig;
 import com.bloxbean.cardano.yacicli.localcluster.ClusterInfo;
+import com.bloxbean.cardano.yacicli.localcluster.NodeMode;
 import com.bloxbean.cardano.yacicli.localcluster.events.ClusterDeleted;
 import com.bloxbean.cardano.yacicli.localcluster.events.ClusterStopped;
 import com.bloxbean.cardano.yacicli.util.PortUtil;
@@ -11,6 +12,7 @@ import com.google.common.collect.EvictingQueue;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -46,6 +48,13 @@ public class YanoService {
     private List<Process> processes = new ArrayList<>();
     private List<ExecutorService> executors = new ArrayList<>();
     private Queue<String> logs = EvictingQueue.create(300);
+
+    // Whether Yano's past-time-travel backfill runs Praos slot-leader checks (VRF-eligible slots only).
+    // auto: on when a Haskell node will validate the chain and activeSlotsCoeff is below 1, or for local
+    // multi-node devnets. true / false force it. The Haskell relay rejects a dense backfill at f < 1 with
+    // VRFLeaderValueTooBig, so without this the chain never syncs and cost models are never enacted.
+    @Value("${yano.past.time.travel.slot.leader.mode:auto}")
+    private String pastTimeTravelSlotLeaderMode = "auto";
 
     public boolean start(ClusterInfo clusterInfo, Path clusterFolder, boolean pastTimeTravelMode, Consumer<String> writer) {
         logs.clear();
@@ -233,6 +242,36 @@ public class YanoService {
         costModels.set(language, aligned);
     }
 
+    /**
+     * Decide whether Yano's past-time-travel backfill should run Praos slot-leader checks.
+     * <p>
+     * Default time travel places one block per slot and ignores VRF eligibility. That is fine while only
+     * Yano consumes the chain, but a Haskell node validating it rejects the first header at
+     * activeSlotsCoeff below 1 with {@code VRFLeaderValueTooBig} and never syncs. So in {@code auto} mode
+     * the checks are on when a Haskell node consumes Yano's chain (companion, yano-primary) and
+     * activeSlotsCoeff is below 1, and for local multi-node devnets as before.
+     */
+    boolean slotLeaderTimeTravelEnabled(ClusterInfo clusterInfo) {
+        String mode = pastTimeTravelSlotLeaderMode == null ? "auto" : pastTimeTravelSlotLeaderMode.trim().toLowerCase();
+        switch (mode) {
+            case "true":
+                return true;
+            case "false":
+                return false;
+            case "auto":
+                break;
+            default:
+                log.warn("Unknown yano.past.time.travel.slot.leader.mode '{}', using auto", pastTimeTravelSlotLeaderMode);
+        }
+        if (clusterInfo.isLocalMultiNodeEnabled()) {
+            return true;
+        }
+        boolean haskellNodeValidatesChain = clusterInfo.getNodeMode() == NodeMode.COMPANION
+                || clusterInfo.getNodeMode() == NodeMode.YANO_PRIMARY;
+        double f = clusterInfo.getActiveSlotsCoeff();
+        return haskellNodeValidatesChain && f > 0 && f < 1.0;
+    }
+
     private Process startYanoProcess(ClusterInfo clusterInfo, Path clusterFolder, Path yanoConfigDir,
                                      boolean pastTimeTravelMode, Consumer<String> writer)
             throws IOException, InterruptedException {
@@ -244,7 +283,8 @@ public class YanoService {
         Files.createDirectories(yanoDataDir);
 
         // Write application.properties for Yano (persists config on disk for debugging)
-        yanoConfigBuilder.build(clusterInfo, yanoConfigDir, yanoDataDir, pastTimeTravelMode);
+        boolean slotLeaderTimeTravel = pastTimeTravelMode && slotLeaderTimeTravelEnabled(clusterInfo);
+        yanoConfigBuilder.build(clusterInfo, yanoConfigDir, yanoDataDir, pastTimeTravelMode, slotLeaderTimeTravel);
 
         ProcessBuilder builder = new ProcessBuilder();
         builder.directory(new File(clusterConfig.getYanoHome()));
@@ -268,8 +308,10 @@ public class YanoService {
 
         if (pastTimeTravelMode) {
             env.put("YANO_BLOCK_PRODUCER_PAST_TIME_TRAVEL_MODE", "true");
-            if (clusterInfo.isLocalMultiNodeEnabled()) {
+            if (slotLeaderTimeTravel) {
                 env.put("YANO_BLOCK_PRODUCER_PAST_TIME_TRAVEL_SLOT_LEADER_MODE", "true");
+                writer.accept(info("Yano past-time-travel uses slot-leader checks (activeSlotsCoeff %s, mode %s)",
+                        clusterInfo.getActiveSlotsCoeff(), pastTimeTravelSlotLeaderMode));
             }
         }
 

--- a/applications/cli/src/main/resources/localcluster/templates/devnet/genesis-templates/spec/config.json
+++ b/applications/cli/src/main/resources/localcluster/templates/devnet/genesis-templates/spec/config.json
@@ -33,7 +33,7 @@
   "TraceBlockFetchServer": false,
   "TraceChainDb": true,
   "TraceChainSyncBlockServer": false,
-  "TraceChainSyncClient": false,
+  "TraceChainSyncClient": true,
   "TraceChainSyncHeaderServer": false,
   "TraceChainSyncProtocol": false,
   "TraceConnectionManager": true,

--- a/applications/cli/src/main/resources/localcluster/templates/devnet/templates/configuration.json
+++ b/applications/cli/src/main/resources/localcluster/templates/devnet/templates/configuration.json
@@ -42,7 +42,7 @@
   "TraceBlockFetchServer": false,
   "TraceChainDb": true,
   "TraceChainSyncBlockServer": false,
-  "TraceChainSyncClient": false,
+  "TraceChainSyncClient": {{traceChainSyncClient}},
   "TraceChainSyncHeaderServer": false,
   "TraceChainSyncProtocol": false,
   "TraceConnectionManager": true,

--- a/applications/cli/src/main/resources/localcluster/templates/devnet/templates/configuration.yaml
+++ b/applications/cli/src/main/resources/localcluster/templates/devnet/templates/configuration.yaml
@@ -189,7 +189,7 @@ TraceBlockchainTime: False
 TraceChainDb: True
 
 # Trace ChainSync client.
-TraceChainSyncClient: False
+TraceChainSyncClient: True
 
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False

--- a/applications/cli/src/test/java/com/bloxbean/cardano/yacicli/localcluster/yano/YanoServiceSlotLeaderTimeTravelTest.java
+++ b/applications/cli/src/test/java/com/bloxbean/cardano/yacicli/localcluster/yano/YanoServiceSlotLeaderTimeTravelTest.java
@@ -1,0 +1,59 @@
+package com.bloxbean.cardano.yacicli.localcluster.yano;
+
+import com.bloxbean.cardano.yacicli.localcluster.ClusterInfo;
+import com.bloxbean.cardano.yacicli.localcluster.NodeMode;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class YanoServiceSlotLeaderTimeTravelTest {
+
+    private static YanoService service(String mode) {
+        YanoService service = new YanoService(null, null, null);
+        ReflectionTestUtils.setField(service, "pastTimeTravelSlotLeaderMode", mode);
+        return service;
+    }
+
+    private static ClusterInfo cluster(NodeMode nodeMode, double activeSlotsCoeff, boolean multiNode) {
+        return ClusterInfo.builder()
+                .nodeMode(nodeMode)
+                .activeSlotsCoeff(activeSlotsCoeff)
+                .localMultiNodeEnabled(multiNode)
+                .build();
+    }
+
+    @Test
+    void autoKeepsDenseBackfillWhenEverySlotIsEligible() {
+        assertThat(service("auto").slotLeaderTimeTravelEnabled(cluster(NodeMode.COMPANION, 1.0, false))).isFalse();
+    }
+
+    @Test
+    void autoTurnsOnSlotLeaderChecksBelowFOneWhenAHaskellNodeValidatesTheChain() {
+        assertThat(service("auto").slotLeaderTimeTravelEnabled(cluster(NodeMode.COMPANION, 0.2, false))).isTrue();
+        assertThat(service("auto").slotLeaderTimeTravelEnabled(cluster(NodeMode.YANO_PRIMARY, 0.5, false))).isTrue();
+    }
+
+    @Test
+    void autoLeavesYanoOnlyDenseBecauseNothingChecksVrfThere() {
+        assertThat(service("auto").slotLeaderTimeTravelEnabled(cluster(NodeMode.YANO_ONLY, 0.2, false))).isFalse();
+    }
+
+    @Test
+    void autoKeepsLocalMultiNodeBehaviour() {
+        assertThat(service("auto").slotLeaderTimeTravelEnabled(cluster(NodeMode.COMPANION, 1.0, true))).isTrue();
+    }
+
+    @Test
+    void explicitValuesOverrideAuto() {
+        assertThat(service("true").slotLeaderTimeTravelEnabled(cluster(NodeMode.YANO_ONLY, 1.0, false))).isTrue();
+        assertThat(service("false").slotLeaderTimeTravelEnabled(cluster(NodeMode.COMPANION, 0.2, true))).isFalse();
+        assertThat(service(" TRUE ").slotLeaderTimeTravelEnabled(cluster(NodeMode.YANO_ONLY, 1.0, false))).isTrue();
+    }
+
+    @Test
+    void unknownValueFallsBackToAuto() {
+        assertThat(service("maybe").slotLeaderTimeTravelEnabled(cluster(NodeMode.COMPANION, 0.2, false))).isTrue();
+        assertThat(service(null).slotLeaderTimeTravelEnabled(cluster(NodeMode.COMPANION, 1.0, false))).isFalse();
+    }
+}

--- a/config/node.properties
+++ b/config/node.properties
@@ -16,6 +16,10 @@ nodeMode=companion
 #updateQuorum=1
 #peerSharing=true
 
+## Node log tracing of the chain-sync client. On by default so a bootstrap chain the node rejects
+## (for example VRFLeaderValueTooBig at activeSlotsCoeff below 1) shows up in the node log.
+#traceChainSyncClient=true
+
 ## Shelley Genesis
 #maxLovelaceSupply=45000000000000000
 #poolPledgeInfluence=0

--- a/docs/pages/node-configuration.mdx
+++ b/docs/pages/node-configuration.mdx
@@ -50,6 +50,12 @@ then you can set `securityParam` to a higher values like `86400` for 1 sec block
     For a real/multi-node network setup, please refer to this known issue/workaround: https://github.com/bloxbean/yaci-devkit/issues/65#issuecomment-2318155838
 </Callout>
 
+### traceChainSyncClient
+
+Whether the node logs its chain-sync client (`TraceChainSyncClient`). Default `true`, so a bootstrap chain the
+node rejects during a Yano handover shows up in the node log instead of failing silently. Set to `false` for a
+quieter log.
+
 ### peerSharing
 
 To enable or disable peer sharing. Default value is `true`.

--- a/docs/pages/yano-node-modes.mdx
+++ b/docs/pages/yano-node-modes.mdx
@@ -38,6 +38,24 @@ This avoids requiring users to wait for two epoch transitions before updated pro
 
 Use companion mode when you want normal Haskell-node behavior, including node socket access, but want DevKit to prepare the chain quickly for PV11 protocol parameters.
 
+### Block time longer than slot length
+
+With `--block-time` larger than `--slot-length`, `activeSlotsCoeff` is below 1 and only VRF-eligible slots may carry
+a block. Yano's default time travel places one block in every slot, which the Haskell node rejects at the first
+header with `VRFLeaderValueTooBig`, so the relay never syncs and the cost-model update is never enacted.
+
+DevKit therefore turns on Yano's slot-leader time travel whenever a Haskell node validates the chain (companion and
+yano-primary modes) and `activeSlotsCoeff` is below 1. The backfill then places blocks only in eligible slots. The
+choice can be forced in `config/application.properties`:
+
+```properties
+# auto (default), true, or false
+yano.past.time.travel.slot.leader.mode=auto
+```
+
+The node configuration template now sets `TraceChainSyncClient` to `true`, so a rejected bootstrap chain shows up in
+the node log instead of failing silently.
+
 ## Yano-only Mode
 
 In `yano-only` mode, Yano runs as the devnet node. There is no Haskell node handover.

--- a/docs/pages/yano-node-modes.mdx
+++ b/docs/pages/yano-node-modes.mdx
@@ -53,8 +53,8 @@ choice can be forced in `config/application.properties`:
 yano.past.time.travel.slot.leader.mode=auto
 ```
 
-The node configuration template now sets `TraceChainSyncClient` to `true`, so a rejected bootstrap chain shows up in
-the node log instead of failing silently.
+The node configuration sets `TraceChainSyncClient` to `true` by default, so a rejected bootstrap chain shows up in
+the node log instead of failing silently. Set `traceChainSyncClient=false` in `node.properties` to turn it off.
 
 ## Yano-only Mode
 


### PR DESCRIPTION
Default time travel places one block per slot and ignores VRF eligibility. That is fine while only Yano consumes the chain, but a Haskell node validating it rejects the first header at activeSlotsCoeff below 1 with {@code VRFLeaderValueTooBig} and never syncs. So in {@code auto} mode the checks are on when a Haskell node consumes Yano's chain (companion, yano-primary) and activeSlotsCoeff is below 1, and for local multi-node devnets as before.