### PR TITLE
genesis: parse stabilityWindowFactor as a double and document it

### DIFF
--- a/applications/cli/config/node.properties
+++ b/applications/cli/config/node.properties
@@ -6,6 +6,12 @@ nodeMode=companion
 #protocolMagic=42
 #maxKESEvolutions=60
 #securityParam=80
+
+## Fraction of the epoch covered by the stability window (3k/f) when securityParam is derived (securityParam=0).
+## k = epochLength * activeSlotsCoeff * stabilityWindowFactor / 3. The Haskell producer can only resume after a
+## gap in block production shorter than 3k/f slots, so this factor times the epoch's wall-clock length is the
+## idle tolerance of the devnet. Values up to about 0.7 are sound (4k/f must stay below the epoch length).
+#stabilityWindowFactor=0.5
 #slotsPerKESPeriod=129600
 #updateQuorum=1
 #peerSharing=true

--- a/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfig.java
+++ b/applications/cli/src/main/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfig.java
@@ -563,7 +563,7 @@ public class GenesisConfig {
             if (updatedValues.get("maxKESEvolutions") != null && !updatedValues.get("maxKESEvolutions").isEmpty())
                 maxKESEvolutions = Integer.parseInt(updatedValues.get("maxKESEvolutions"));
             if (updatedValues.get("stabilityWindowFactor") != null && !updatedValues.get("stabilityWindowFactor").isEmpty())
-                stabilityWindowFactor = Integer.parseInt(updatedValues.get("stabilityWindowFactor"));
+                stabilityWindowFactor = Double.parseDouble(updatedValues.get("stabilityWindowFactor"));
             if (updatedValues.get("securityParam") != null && !updatedValues.get("securityParam").isEmpty())
                 securityParam = Integer.parseInt(updatedValues.get("securityParam"));
             if (updatedValues.get("slotsPerKESPeriod") != null && !updatedValues.get("slotsPerKESPeriod").isEmpty())

--- a/applications/cli/src/test/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfigMergeTest.java
+++ b/applications/cli/src/test/java/com/bloxbean/cardano/yacicli/localcluster/config/GenesisConfigMergeTest.java
@@ -1,0 +1,30 @@
+package com.bloxbean.cardano.yacicli.localcluster.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GenesisConfigMergeTest {
+
+    @Test
+    void mergeAcceptsFractionalStabilityWindowFactor() {
+        GenesisConfig config = new GenesisConfig();
+
+        config.merge(Map.of("stabilityWindowFactor", "0.7"));
+
+        assertThat(config.getStabilityWindowFactor()).isEqualTo(0.7);
+    }
+
+    @Test
+    void mergeLeavesStabilityWindowFactorAloneWhenAbsentOrBlank() {
+        GenesisConfig config = new GenesisConfig();
+
+        config.merge(Map.of("securityParam", "80"));
+        assertThat(config.getStabilityWindowFactor()).isEqualTo(0.5);
+
+        config.merge(Map.of("stabilityWindowFactor", ""));
+        assertThat(config.getStabilityWindowFactor()).isEqualTo(0.5);
+    }
+}

--- a/config/node.properties
+++ b/config/node.properties
@@ -12,6 +12,12 @@ nodeMode=companion
 
 #maxKESEvolutions=60
 #securityParam=80
+
+## Fraction of the epoch covered by the stability window (3k/f) when securityParam is derived (securityParam=0).
+## k = epochLength * activeSlotsCoeff * stabilityWindowFactor / 3. The Haskell producer can only resume after a
+## gap in block production shorter than 3k/f slots, so this factor times the epoch's wall-clock length is the
+## idle tolerance of the devnet. Values up to about 0.7 are sound (4k/f must stay below the epoch length).
+#stabilityWindowFactor=0.5
 #slotsPerKESPeriod=129600
 #updateQuorum=1
 #peerSharing=true

--- a/docs/pages/node-configuration.mdx
+++ b/docs/pages/node-configuration.mdx
@@ -50,6 +50,28 @@ then you can set `securityParam` to a higher values like `86400` for 1 sec block
     For a real/multi-node network setup, please refer to this known issue/workaround: https://github.com/bloxbean/yaci-devkit/issues/65#issuecomment-2318155838
 </Callout>
 
+### stabilityWindowFactor
+
+When `securityParam` is left at `0`, DevKit derives it from the epoch length so that the stability window
+(`3k/f` slots) covers this fraction of the epoch:
+
+```
+securityParam = epochLength * activeSlotsCoeff * stabilityWindowFactor / 3
+```
+
+The default is `0.5`, half an epoch. The Haskell block producer can only check leadership for slots within
+`3k/f` of its chain tip, so a gap in block production longer than that (the host asleep, the container stopped)
+freezes the chain until it is reset. This factor times the epoch's wall-clock length is therefore the devnet's
+idle tolerance. Raising it buys tolerance without a longer epoch:
+
+```shell
+stabilityWindowFactor=0.7
+```
+
+Values up to about `0.7` are sound: `4k/f` must stay below the epoch length for the epoch nonce schedule, and
+the rewards calculation needs the stability window inside the epoch. Setting `securityParam` explicitly bypasses
+this derivation.
+
 ### peerSharing
 
 To enable or disable peer sharing. Default value is `true`.


### PR DESCRIPTION
The admin-update merge path parsed this double field with Integer.parseInt, so any fractional value (the only useful kind) threw. The properties-file path already bound it correctly.

- parse with Double.parseDouble in GenesisConfig.merge
- explain the k derivation and the idle tolerance it fixes in the node-configuration page and in node.properties